### PR TITLE
feat [DAT-4136] - :wrench: Provide a pre-stop script

### DIFF
--- a/charts/rudderstack/Chart.yaml
+++ b/charts/rudderstack/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/rudderstack/pre-stop.sh
+++ b/charts/rudderstack/pre-stop.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Install JQ
+JQ=/usr/bin/jq
+curl -sLo $JQ https://stedolan.github.io/jq/download/linux64/jq
+chmod +x $JQ
+
+# Extract source IDs
+SOURCE_IDS=$(more $RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH | jq -r .sources[].id)
+
+# Check pending events per Source ID
+HAS_PENDING_EVENTS=true
+while $HAS_PENDING_EVENTS ; do
+    TOTAL_PENDING_EVENTS=0
+    echo "1. Checking pending events...."
+    for source_id in $SOURCE_IDS; do
+      PENDING_EVENTS=$(curl -s --request POST --url http://localhost:8080/v1/pending-events \
+           -u ${source_id}:potato --header 'Content-Type: application/json' \
+           --data "{\"source_id\": \"${source_id}\"}" | jq .pending_events)
+      echo "2. Pending $PENDING_EVENTS events for Source [$source_id]"
+      TOTAL_PENDING_EVENTS=$(( $TOTAL_PENDING_EVENTS + $PENDING_EVENTS ))
+    done
+    echo "3. Checking result..."
+    if [ ${TOTAL_PENDING_EVENTS} -eq 0 ]; then
+       echo "4. No pending events"
+       HAS_PENDING_EVENTS=false
+    else
+       echo "4. Total pending events: $TOTAL_PENDING_EVENTS"
+    fi
+    echo "5. Sleeping for 5 seconds..."
+    sleep 5s
+done

--- a/charts/rudderstack/templates/configmap-rudder-server.yaml
+++ b/charts/rudderstack/templates/configmap-rudder-server.yaml
@@ -13,4 +13,6 @@ data:
   {{- if .Values.backend.controlPlaneJSON}}
   workspaceConfig.json: |-
 {{.Files.Get "workspaceConfig.json" | indent 4}}
+  pre-stop.sh: |-
+{{.Files.Get "pre-stop.sh" | indent 4}}
   {{- end }}

--- a/charts/rudderstack/templates/statefulset.yaml
+++ b/charts/rudderstack/templates/statefulset.yaml
@@ -115,6 +115,12 @@ spec:
             value: {{ .Release.Namespace }}
         command: ["/docker-entrypoint.sh"]
         args: ["/bin/sh","-c","/wait-for $JOBS_DB_HOST:$(JOBS_DB_PORT) -- /rudder-server"]
+        {{- if .Values.backend.controlPlaneJSON }}
+        lifecycle:
+          preStop:
+            exec:
+              command: [ "/pre-stop.sh" ]
+        {{- end }}
       {{- if .Values.telegraf_sidecar.enabled }}
       - name: {{ include "telegraf-sidecar.name" .}}
         image: "{{ .Values.telegraf_sidecar.image.repo }}:{{ .Values.telegraf_sidecar.image.tag }}"

--- a/charts/rudderstack/templates/statefulset.yaml
+++ b/charts/rudderstack/templates/statefulset.yaml
@@ -119,7 +119,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: [ "/pre-stop.sh" ]
+              command: [ "{{ .Values.backend.config.mountPath }}/pre-stop.sh" ]
         {{- end }}
       {{- if .Values.telegraf_sidecar.enabled }}
       - name: {{ include "telegraf-sidecar.name" .}}


### PR DESCRIPTION
This PR aims to add a `pre-stop` script forcing the Warehouse destination to flush their pending events. Useful when the HPA is removing the POD from the service due to lower activity.