### PR TITLE
feat [DAT-4136] - 🔧 Emit statsd pre-stop hook points

### DIFF
--- a/charts/rudderstack/Chart.yaml
+++ b/charts/rudderstack/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/rudderstack/pre-stop.sh
+++ b/charts/rudderstack/pre-stop.sh
@@ -7,12 +7,18 @@ chmod +x $JQ
 
 # Extract source IDs
 SOURCE_IDS=$(more $RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH | jq -r .sources[].id)
+STATSD_PREFIX="rudder_server_pre_stop"
+
+# Emit Start datum to Telegraf
+echo "${STATSD_PREFIX}_start:1|c" | nc -w 1 -u localhost 8125
 
 # Check pending events per Source ID
 HAS_PENDING_EVENTS=true
 while $HAS_PENDING_EVENTS ; do
     TOTAL_PENDING_EVENTS=0
     echo "1. Checking pending events...."
+    echo "${STATSD_PREFIX}_check:1|c" | nc -w 1 -u localhost 8125
+
     for source_id in $SOURCE_IDS; do
       PENDING_EVENTS=$(curl -s --request POST --url http://localhost:8080/v1/pending-events \
            -u ${source_id}:potato --header 'Content-Type: application/json' \
@@ -20,7 +26,9 @@ while $HAS_PENDING_EVENTS ; do
       echo "2. Pending $PENDING_EVENTS events for Source [$source_id]"
       TOTAL_PENDING_EVENTS=$(( $TOTAL_PENDING_EVENTS + $PENDING_EVENTS ))
     done
+
     echo "3. Checking result..."
+    echo "${STATSD_PREFIX}_pending_events:$TOTAL_PENDING_EVENTS|g" | nc -w 1 -u localhost 8125
     if [ ${TOTAL_PENDING_EVENTS} -eq 0 ]; then
        echo "4. No pending events"
        HAS_PENDING_EVENTS=false
@@ -29,4 +37,7 @@ while $HAS_PENDING_EVENTS ; do
     fi
     echo "5. Sleeping for 5 seconds..."
     sleep 5s
+
 done
+
+echo "${STATSD_PREFIX}_done:1|c" | nc -w 1 -u localhost 8125


### PR DESCRIPTION
This PR aims to emit StatsD metrics from the pre-stop hook to Telegraf endpoint `localhost:8125` so it can forward it to the telegraf defined outputs.